### PR TITLE
[#2] fix glitch of sticky header because of margin or divider

### DIFF
--- a/sample/src/main/java/com/shuhart/stickyheader/MainActivity.java
+++ b/sample/src/main/java/com/shuhart/stickyheader/MainActivity.java
@@ -1,7 +1,9 @@
 package com.shuhart.stickyheader;
 
+import android.content.res.Configuration;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 
@@ -13,12 +15,19 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
         RecyclerView recyclerView = findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
+
+        DividerItemDecoration dividerDecorator = new DividerItemDecoration(this, DividerItemDecoration.VERTICAL);
+        recyclerView.addItemDecoration(dividerDecorator);
+
         SectionAdapter adapter = new SectionAdapter();
         recyclerView.setAdapter(adapter);
+
         StickyHeaderItemDecorator decorator = new StickyHeaderItemDecorator(adapter);
         decorator.attachToRecyclerView(recyclerView);
+
         adapter.items = new ArrayList<Section>() {{
             int section = 0;
 //            add(new CustomHeader());

--- a/sample/src/main/res/layout/recycler_view_item.xml
+++ b/sample/src/main/res/layout/recycler_view_item.xml
@@ -2,7 +2,9 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="?listPreferredItemHeight">
+    android:layout_height="?listPreferredItemHeight"
+    android:layout_marginTop="16dp"
+    android:layout_marginBottom="16dp">
 
     <TextView
         android:id="@+id/text_view"

--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -85,13 +85,25 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
         } else {
             preOverlappedPosition = adapter.getHeaderPositionForItem(topChildPosition);
         }
-        if (preOverlappedPosition != RecyclerView.NO_POSITION && preOverlappedPosition != overlappedHeaderPosition) {
+
+        if (preOverlappedPosition == RecyclerView.NO_POSITION) {
+            return;
+        }
+
+        if (preOverlappedPosition != overlappedHeaderPosition && shouldMoveHeader(viewOverlappedByHeader)) {
             updateStickyHeader(topChildPosition, overlappedByHeaderPosition);
             moveHeader(c, viewOverlappedByHeader);
-        } else if (preOverlappedPosition != RecyclerView.NO_POSITION){
+        } else {
             updateStickyHeader(topChildPosition, RecyclerView.NO_POSITION);
             drawHeader(c);
         }
+    }
+
+    // shouldMoveHeader returns the sticky header should move or not.
+    // This method is for avoiding sinking/departing the sticky header into/from top of screen
+    private boolean shouldMoveHeader(View viewOverlappedByHeader) {
+        int dy = (viewOverlappedByHeader.getTop() - viewOverlappedByHeader.getHeight());
+        return (viewOverlappedByHeader.getTop() >= 0 && dy <= 0);
     }
 
     @SuppressWarnings("unchecked")

--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -15,6 +15,7 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
     private int currentStickyPosition = RecyclerView.NO_POSITION;
     private RecyclerView recyclerView;
     private RecyclerView.ViewHolder currentStickyHolder;
+    private View lastViewOverlappedByHeader = null;
 
     public StickyHeaderItemDecorator(@NonNull StickyAdapter adapter) {
         this.adapter = adapter;
@@ -68,8 +69,14 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
 
         View viewOverlappedByHeader = getChildInContact(parent, currentStickyHolder.itemView.getBottom());
         if (viewOverlappedByHeader == null) {
-            return;
+            if (lastViewOverlappedByHeader != null) {
+                viewOverlappedByHeader = lastViewOverlappedByHeader;
+            } else {
+                return;
+            }
         }
+        lastViewOverlappedByHeader = viewOverlappedByHeader;
+
         int overlappedByHeaderPosition = parent.getChildAdapterPosition(viewOverlappedByHeader);
         int overlappedHeaderPosition = adapter.getHeaderPositionForItem(overlappedByHeaderPosition);
         int preOverlappedPosition;

--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -72,7 +72,7 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
             if (lastViewOverlappedByHeader != null) {
                 viewOverlappedByHeader = lastViewOverlappedByHeader;
             } else {
-                return;
+                viewOverlappedByHeader = parent.getChildAt(topChildPosition);
             }
         }
         lastViewOverlappedByHeader = viewOverlappedByHeader;


### PR DESCRIPTION
Hi, here's pull request for #2 .
Here's summary of modification:
- Modifications of 76a6ca3 and 9e06b4c if only for reproduce the issue. Insert margin and divider in recycler view.
- Latter commits fix the issue.
  - c327e3c If there's no view which contact with header (because of margin or divider), use "last view which was overlapped by header" as a view contacting with header.
  - e2bda5d If there's not "last view which was overlapped by header" (e.g. initial state), then use first child as the place of it.
  - 2a1e3a5 Margin or divider causes the header to be sunk/departed into/from top of screen. If the moving header position goes unexpected value, stop moving but just drawing.

I'm so happy if you check this pull request and give me feedback. Thanks!