### PR TITLE
Bugfix: Remove callbacks from old RecyclerView

### DIFF
--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -25,8 +25,8 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
         if (this.recyclerView == recyclerView) {
             return; // nothing to do
         }
-        if (recyclerView != null) {
-            destroyCallbacks(recyclerView);
+        if (this.recyclerView != null) {
+            destroyCallbacks(this.recyclerView);
         }
         this.recyclerView = recyclerView;
         if (recyclerView != null) {


### PR DESCRIPTION
When attachToRecyclerView is called a second time, this commit correctly removes the item decoration callbacks from the previous RecyclerView