### PR TITLE
Prevent visual glitch during fast scrolling

### DIFF
--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -78,12 +78,14 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
         lastViewOverlappedByHeader = viewOverlappedByHeader;
 
         int overlappedByHeaderPosition = parent.getChildAdapterPosition(viewOverlappedByHeader);
-        int overlappedHeaderPosition = adapter.getHeaderPositionForItem(overlappedByHeaderPosition);
+        int overlappedHeaderPosition;
         int preOverlappedPosition;
         if (overlappedByHeaderPosition > 0) {
             preOverlappedPosition = adapter.getHeaderPositionForItem(overlappedByHeaderPosition - 1);
+            overlappedHeaderPosition = adapter.getHeaderPositionForItem(overlappedByHeaderPosition);
         } else {
             preOverlappedPosition = adapter.getHeaderPositionForItem(topChildPosition);
+            overlappedHeaderPosition = preOverlappedPosition;
         }
 
         if (preOverlappedPosition == RecyclerView.NO_POSITION) {


### PR DESCRIPTION
On a recyclerview with margins on the items, sometimes there was a short glitch if the lastViewOverlappedByHeader was not currently bound any more and getChildInContact returned null (because the bottom of the header fell into the margin between items).
This mostly occurred during fast scrolling.
This commit fixes the issue.