### PR TITLE
Header should recalculate its height

### DIFF
--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -117,6 +117,7 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
         } else if (headerPositionForItem != RecyclerView.NO_POSITION) {
             adapter.onBindHeaderViewHolder(currentStickyHolder, headerPositionForItem);
         }
+        fixLayoutSize();
     }
 
     private void drawHeader(Canvas c) {


### PR DESCRIPTION
There was issue, when header changes its size but continues to use old sizes.
It happened because `fixLayoutSize()` is called only once during initialization, but should be called after header binding.