### PR TITLE
Fix Header size recalculation (activity.recreate, ...)

### DIFF
--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -149,10 +149,10 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
     }
 
     private void fixLayoutSize() {
-        recyclerView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+        recyclerView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
             @Override
-            public void onGlobalLayout() {
-                recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+            public void onLayoutChange(View view, int i, int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
+                recyclerView.removeOnLayoutChangeListener(this);
                 // Specs for parent (RecyclerView)
                 int widthSpec = View.MeasureSpec.makeMeasureSpec(recyclerView.getWidth(), View.MeasureSpec.EXACTLY);
                 int heightSpec = View.MeasureSpec.makeMeasureSpec(recyclerView.getHeight(), View.MeasureSpec.UNSPECIFIED);


### PR DESCRIPTION
In certain circumstances Sticky Header size is recalculated when not visible. Usually Header width becomes 0 when this happens and Header disappear.
Replacing OnGlobalLayoutListener with OnLayoutChangeListener fixes the problem.