### PR TITLE
Fixes NullPointerException in onGlobalLayout

### DIFF
--- a/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
+++ b/stickyheader/src/main/java/com/shuhart/stickyheader/StickyHeaderItemDecorator.java
@@ -153,6 +153,9 @@ public class StickyHeaderItemDecorator extends RecyclerView.ItemDecoration {
         recyclerView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
+                if (recyclerView == null) {
+					return;
+                }
                 recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                 // Specs for parent (RecyclerView)
                 int widthSpec = View.MeasureSpec.makeMeasureSpec(recyclerView.getWidth(), View.MeasureSpec.EXACTLY);


### PR DESCRIPTION
This NPE occurred in the wild, probably due to a race condition.